### PR TITLE
list midi devices, recv input mesgs, example app

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "dart.flutterSdkPath": "/home/maks/fvm/versions/master"
+}

--- a/README.md
+++ b/README.md
@@ -1,18 +1,8 @@
 # flutter_midi_command_web
 
-A new Flutter plugin.
+Federated Flutter plugin for Web platform implementing the interface from the [flutter_midi_command_platform_interface](https://github.com/InvisibleWrench/flutter_midi_command_platform_interface)
 
 ## Getting Started
 
-This project is a starting point for a Flutter
-[plug-in package](https://flutter.dev/developing-packages/),
-a specialized package that includes platform-specific implementation code for
-Android and/or iOS.
+Until this plugin is endorsed by the main [FlutterMidiCommand plugin](https://github.com/InvisibleWrench/FlutterMidiCommand) you will need to include both the interface and this plugin as dependencies, please see the example app in this repo for how to do this.
 
-For help getting started with Flutter, view our
-[online documentation](https://flutter.dev/docs), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
-
-The plugin project was generated without specifying the `--platforms` flag, no platforms are currently supported.
-To add platforms, run `flutter create -t plugin --platforms <platforms> .` under the same
-directory. You can also find a detailed instruction on how to add platforms in the `pubspec.yaml` at https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin-platforms.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.15.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,21 +56,42 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.2.0"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.2"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_midi_command_platform_interface:
+  flutter_midi_command:
+    dependency: "direct main"
+    description:
+      path: "../../FlutterMidiCommand"
+      relative: true
+    source: path
+    version: "0.3.0"
+  flutter_midi_command_linux:
     dependency: transitive
     description:
-      path: "../../flutter_midi_command_platform_interface"
+      path: "../../flutter_midi_command_linux"
       relative: true
     source: path
     version: "0.2.0"
+  flutter_midi_command_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_midi_command_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.4"
   flutter_midi_command_web:
-    dependency: "direct main"
+    dependency: transitive
     description:
       path: ".."
       relative: true
@@ -92,35 +113,63 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.4"
+  js_bindings:
+    dependency: transitive
+    description:
+      name: js_bindings
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.5"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.7.0"
+  midi:
+    dependency: transitive
+    description:
+      name: midi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.2"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.1"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "2.1.2"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1+1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -132,56 +181,63 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety"
+    version: "0.4.9"
+  tuple:
+    dependency: transitive
+    description:
+      name: tuple
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
-  flutter: ">=1.20.0 <2.0.0"
+  dart: ">=2.16.0 <3.0.0"
+  flutter: ">=2.5.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,19 +6,14 @@ description: Demonstrates how to use the flutter_midi_command_web plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.16.0 <3.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
 
-  flutter_midi_command_web:
-    # When depending on this package from a real application you should use:
-    #   flutter_midi_command_web: ^x.y.z
-    # See https://dart.dev/tools/pub/dependencies#version-constraints
-    # The example app is bundled with the plugin so we use a path dependency on
-    # the parent directory to use the current plugin's version.
-    path: ../
+  flutter_midi_command:
+    path: ../../FlutterMidiCommand
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -5,23 +5,8 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:flutter_midi_command_web_example/main.dart';
-
 void main() {
-  testWidgets('Verify Platform version', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
-
-    // Verify that platform version is retrieved.
-    expect(
-      find.byWidgetPredicate(
-        (Widget widget) => widget is Text &&
-                           widget.data.startsWith('Running on:'),
-      ),
-      findsOneWidget,
-    );
-  });
+  testWidgets('Verify Platform version', (WidgetTester tester) async {});
 }

--- a/lib/extensions.dart
+++ b/lib/extensions.dart
@@ -1,0 +1,8 @@
+extension IterableExtension<T> on Iterable<T> {
+  T? firstWhereOrNull(bool Function(T element) test) {
+    for (var element in this) {
+      if (test(element)) return element;
+    }
+    return null;
+  }
+}

--- a/lib/flutter_midi_command_web.dart
+++ b/lib/flutter_midi_command_web.dart
@@ -1,155 +1,146 @@
 import 'dart:async';
-// import 'dart:js';
-
-@JS()
-import 'package:js/js.dart';
-import 'dart:html' as html;
+import 'dart:js_util' as js_util;
 import 'dart:typed_data';
-import 'package:meta/meta.dart';
-import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter_midi_command_platform_interface/flutter_midi_command_platform_interface.dart';
+import 'package:flutter_midi_command_web/extensions.dart';
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+import 'package:js/js.dart';
+import 'package:js_bindings/js_bindings.dart' as html;
 
+final List<html.MIDIInput> _webMidiInputs = [];
+final List<html.MIDIOutput> _webMidiOutputs = [];
+final List<MidiDevice> _connectedDevices = [];
+
+/// A web implementation of the FlutterMidiCommandWeb plugin.
 class FlutterMidiCommandWeb extends MidiCommandPlatform {
-  html.Window _window;
+  final StreamController<MidiPacket> _rxStreamController =
+      StreamController<MidiPacket>.broadcast();
 
-  html.MidiAccess _access;
+  final StreamController<String> _setupStreamController =
+      StreamController<String>.broadcast();
 
-  StreamController<Uint8List> _rxStreamController = StreamController<Uint8List>.broadcast();
-  Stream<Uint8List> _rxStream = StreamController<Uint8List>.broadcast().stream;
-  StreamController<String> _setupStreamController = StreamController<String>.broadcast();
-  Stream<String> _setupStream;
+  late final Stream<String> _setupStream;
+  late final Stream<MidiPacket> _rxStream;
 
-  /// A constructor that allows tests to override the window object used by the plugin.
-  FlutterMidiCommandWeb({@visibleForTesting html.Window window}) {
-    _window = window ?? html.window;
-    _requestMidiAccess();
-  }
-
-  /// Registers this class as the default instance of [UrlLauncherPlatform].
   static void registerWith(Registrar registrar) {
+    _log("register FlutterMidiCommandWeb");
     MidiCommandPlatform.instance = FlutterMidiCommandWeb();
   }
 
-  _requestMidiAccess() async {
-    _window.navigator.requestMidiAccess({'sysex': true}).then((value) {
-      print("succes $value");
-      _access = value;
-      _access.on['statechange'].listen(_handleMIDIStateChange);
+  FlutterMidiCommandWeb() {
+    _setupStream = _setupStreamController.stream;
+    _rxStream = _rxStreamController.stream;
 
-
-    });
-
-    // JsFunction func = context['navigator']['requestMIDIAccess'];
-    // JsObject promise = func.apply([], thisArg: context['navigator']);
-    //
-    // promise.callMethod('then', [handler]);
-
-
-
-    final JS. w = new JsObject.fromBrowserObject(_window);
-    final JsObject n = w['navigator'];
-
-    if (n.hasProperty('requestMIDIAccess')) {
-      n.callMethod('requestMIDIAccess').callMethod('then', [
-        (JsObject midiAccess) {
-          print(midiAccess);
-          print(midiAccess.hasProperty('inputs'));
-          JsObject inputs = JsObject.fromBrowserObject(midiAccess['inputs']);
-          print(inputs);
-
-          // JsObject.fromBrowserObject(object)
-          // js.scoped(() {
-          //   String json = js.context.JSON.stringify(js.context.myMap);
-          //   Map map = JSON.parse(json);
-          //   // iterate on dart Map
-          // });
-
-          var inputValues = inputs.callMethod('values');
-          print(inputValues);
-          // JsObject inputIterator = inputValues.callMethod('foreach');
-          // print(inputIterator);
-          for (JsObject input in inputValues) {
-            print(input['name']);
-          }
-          // ;
-          // sendMiddleC(midiAccess, 1);
-        }
-      ]);
-    }
+    _initMidi();
   }
 
-  void handler(html.MidiAccess access) {
-    print("access $access");
+  void _initMidi() async {
+    final access = await html.window.navigator
+        .requestMIDIAccess(html.MIDIOptions(sysex: true, software: false));
+
+    // deal with bug: https://github.com/dart-lang/sdk/issues/33248
+    js_util.callMethod(access.inputs, 'forEach', [allowInterop(_getInputs)]);
+    js_util.callMethod(access.outputs, 'forEach', [allowInterop(_getOutputs)]);
+  }
+
+  void _getInputs(dynamic a, dynamic b, dynamic c) {
+    final inp = a as html.MIDIInput;
+    _log('input id, name: ${inp.id} | ${inp.name}');
+    _webMidiInputs.add(inp);
+  }
+
+  void _getOutputs(dynamic a, dynamic b, dynamic c) {
+    final outp = a as html.MIDIOutput;
+    _log('ouput id, name: ${outp.id} | ${outp.name}');
+    _webMidiOutputs.add(outp);
   }
 
   @override
   Future<List<MidiDevice>> get devices async {
-    // JsObject i = new JsObject.fromBrowserObject(object)
-    // _access.inputs.forEach((key, value) {
-    //   print("input key ${key} ${value}");
-    //   // print( "Input port [type:'${element.type}'] id:'${element.id}' manufacturer:'${element.manufacturer}' name:'${element.name}' version:'${element.version}'");
-    //   // element.value.onMidiMessage.listen(_handleMidiIn);
-    //   // html.MidiPort inPort = element as html.MidiPort;
-    //   // value.on['midimessage'].listen(_handleMidiIn);
-    // });
-
-    // _access.outputs.forEach((key, value) {
-    //   print("output ${key} ${value}");
-    // });
-
-    // var devs = await _methodChannel.invokeMethod('getDevices');
-    // return devs.map<MidiDevice>((m) {
-    //   var map = m.cast<String, Object>();
-    //   return MidiDevice(map["id"], map["name"], map["type"], map["connected"] == "true");
-    // }).toList();
-  }
-
-  _handleMIDIStateChange(evt) {
-    var connEvt = evt as html.MidiConnectionEvent;
-    print("state ${connEvt.port}");
-    _setupStreamController.sink.add(connEvt.type);
-  }
-
-  _handleMidiIn(html.MidiMessageEvent evt) {
-    print("midi in $evt");
+    final deviceMap = <String, MidiDevice>{};
+    int idCounter = 0;
+    for (var input in _webMidiInputs) {
+      final isConnected = _connectedDevices
+              .firstWhereOrNull((device) => device.name == input.name) !=
+          null;
+      final device = MidiDevice(input.id, input.name ?? '', "web", isConnected);
+      device.inputPorts.add(MidiPort(idCounter++, MidiPortType.IN));
+      deviceMap[input.name ?? input.id] = device;
+    }
+    idCounter = 0;
+    for (var output in _webMidiOutputs) {
+      final isConnected = _connectedDevices
+              .firstWhereOrNull((device) => device.name == output.name) !=
+          null;
+      final existingDevice = deviceMap[output.name];
+      if (existingDevice != null) {
+        existingDevice.outputPorts.add(MidiPort(idCounter++, MidiPortType.OUT));
+      } else {
+        final device =
+            MidiDevice(output.id, output.name ?? '', "web", isConnected);
+        device.outputPorts.add(MidiPort(idCounter++, MidiPortType.OUT));
+        deviceMap[output.name ?? output.id] = device;
+      }
+    }
+    return deviceMap.values.toList();
   }
 
   /// Connects to the device.
   @override
-  void connectToDevice(MidiDevice device) {
-    // _methodChannel.invokeMethod('connectToDevice', device.toDictionary);
+  void connectToDevice(MidiDevice device, {List<MidiPort>? ports}) {
+    // connect up incoming webmidi data to our rx stream of MidiPackets
+    final inputPorts = _webMidiInputs.where((p) => p.name == device.name);
+    for (var inport in inputPorts) {
+      _log('connecting midi rx to: ${device.name}');
+      inport.onmidimessage = allowInterop((midiMesg) {
+        _rxStreamController.add(
+            // TODO: add actual timestamp param instead of 0
+            MidiPacket((midiMesg as html.MIDIMessageEvent).data, 0, device));
+      });
+    }
+    _connectedDevices.add(device);
+    _setupStreamController.add("deviceConnected");
   }
 
   /// Disconnects from the device.
   @override
-  void disconnectDevice(MidiDevice device) {
-    // _methodChannel.invokeMethod('disconnectDevice', device.toDictionary);
+  void disconnectDevice(MidiDevice device, {bool remove = true}) {
+    final inputPorts = _webMidiInputs.where((p) => p.name == device.name);
+    for (var inport in inputPorts) {
+      _log('connecting midi rx to: ${device.name}');
+      inport.onmidimessage = allowInterop((midiMesg) {
+        _rxStreamController.add(
+            // TODO: add actual timestamp param instead of 0
+            MidiPacket((midiMesg as html.MIDIMessageEvent).data, 0, device));
+      });
+      _connectedDevices.remove(device);
+      _setupStreamController.add("deviceDisconnected");
+    }
   }
 
   @override
   void teardown() {
-    // _methodChannel.invokeMethod('teardown');
+    //TODO: go through and call disconnect on all devics, then close rx stream
   }
 
-  /// Sends data to the currently connected device.
+  /// Sends data to the currently connected device.wmidi hardware driver name
   ///
   /// Data is an UInt8List of individual MIDI command bytes.
   @override
-  void sendData(Uint8List data) {
-    print("send $data through method channel");
-    // _methodChannel.invokeMethod('sendData', data);
+  void sendData(Uint8List data, {int? timestamp, String? deviceId}) {
+    // _connectedDevices.values.forEach((device) {
+    //   // print("send to $device");
+    //   device.send(data, data.length);
+    // });
   }
 
   /// Stream firing events whenever a midi package is received.
   ///
   /// The event contains the raw bytes contained in the MIDI package.
   @override
-  Stream<Uint8List> get onMidiDataReceived {
-    print("get on midi data");
-    // _rxStream ??= _rxChannel.receiveBroadcastStream().map<Uint8List>((d) {
-    //   return Uint8List.fromList(List<int>.from(d));
-    // });
-    _rxStream ??= _rxStreamController.stream;
+  Stream<MidiPacket>? get onMidiDataReceived {
     return _rxStream;
   }
 
@@ -157,8 +148,13 @@ class FlutterMidiCommandWeb extends MidiCommandPlatform {
   ///
   /// For example, when a new BLE devices is discovered.
   @override
-  Stream<String> get onMidiSetupChanged {
-    _setupStream ??= _setupStreamController.stream;
+  Stream<String>? get onMidiSetupChanged {
     return _setupStream;
+  }
+}
+
+void _log(String mesg) {
+  if (kDebugMode) {
+    print(mesg);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,61 +7,68 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   flutter_midi_command_platform_interface:
     dependency: "direct main"
     description:
-      path: "../flutter_midi_command_platform_interface"
-      relative: true
-    source: path
-    version: "0.2.0"
+      name: flutter_midi_command_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -78,35 +85,56 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.4"
+  js_bindings:
+    dependency: "direct main"
+    description:
+      name: js_bindings
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.5"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.1"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "2.1.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -118,56 +146,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
-  flutter: ">=1.20.0 <2.0.0"
+  dart: ">=2.16.0 <3.0.0"
+  flutter: ">=2.5.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,18 +11,19 @@ flutter:
         fileName: flutter_midi_command_web.dart
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
-  flutter: ">=1.20.0 <2.0.0"
+  sdk: ">=2.16.0 <3.0.0"
+  flutter: ">=2.5.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_midi_command_platform_interface:
-    path: "../flutter_midi_command_platform_interface"
   flutter_web_plugins:
-    sdk: flutter
-  js: ^0.6.2
+    sdk: flutter  
+  flutter_midi_command_platform_interface: ^0.3.2
+  js: ^0.6.4
+  js_bindings: 0.0.5
 
 dev_dependencies:
+  flutter_lints: ^1.0.0
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
This PR adds some initial working support for:

- listing midi devices
- connecting to a device
- receiving input midi messages from a device

Because I'm using `js_bindings` which aims to replace `dart:html` but is based on the latest version of `package:js` this currently requires Flutter master channel.

Todo in future PR:
- sending midi messages
- handling device connect/disconnect events