### PR TITLE
Sending midi

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -4,13 +4,6 @@ Demonstrates how to use the flutter_midi_command_web plugin.
 
 ## Getting Started
 
-This project is a starting point for a Flutter application.
+This example is intended to work with an Akai Fire midi-controller, but incoming midi events should be displayed for any midi controller, while the demonstration of sending midi data is Fire specific.
 
-A few resources to get you started if this is your first Flutter project:
-
-- [Lab: Write your first Flutter app](https://flutter.dev/docs/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://flutter.dev/docs/cookbook)
-
-For help getting started with Flutter, view our
-[online documentation](https://flutter.dev/docs), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+Note: currently there is a bug with displaying the listview of available midi devices on app start, so you need to do a hot-reload in order to get the listview items ui to appear.

--- a/example/lib/fire_midi.dart
+++ b/example/lib/fire_midi.dart
@@ -1,0 +1,26 @@
+List<int> fireAllPads(int r, int g, int b) {
+  const sysexHeader = [
+    0xF0,
+    0x47,
+    0x7F,
+    0x43,
+    0x65,
+    0x02,
+    0x00, // mesg length - low byte
+  ];
+  const sysexFooter = [
+    0xF7, // End of Exclusive
+  ];
+  final allLeds = <int>[];
+  for (int idx = 0; idx < 64; idx++) {
+    final ledData = [
+      idx,
+      r,
+      g,
+      b,
+    ];
+    allLeds.addAll(ledData);
+  }
+  final midiData = <int>[...sysexHeader, ...allLeds, ...sysexFooter];
+  return midiData;
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_midi_command/flutter_midi_command.dart';
+import 'package:flutter_midi_command_web_example/fire_midi.dart';
 
 void main() {
   runApp(const MyApp());
@@ -76,6 +77,13 @@ class _MyAppState extends State<MyApp> {
                             }),
                       ),
                       Text('Last midi: $lastMidiMesg'),
+                      MaterialButton(
+                          child: Text('FIRE ALL PADS OFF'),
+                          onPressed: () {
+                            print('send all off');
+                            _midiCommand.sendData(
+                                Uint8List.fromList(fireAllPads(0, 10, 70)));
+                          })
                     ],
                   );
                 })),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -82,7 +82,7 @@ class _MyAppState extends State<MyApp> {
                           onPressed: () {
                             print('send all off');
                             _midiCommand.sendData(
-                                Uint8List.fromList(fireAllPads(0, 10, 70)));
+                                Uint8List.fromList(fireAllPads(0, 0, 0)));
                           })
                     ],
                   );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -120,7 +120,7 @@ packages:
       name: js_bindings
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.5"
+    version: "0.0.6-dev"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -75,21 +75,21 @@ packages:
       path: "../../FlutterMidiCommand"
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.2"
   flutter_midi_command_linux:
     dependency: transitive
     description:
-      path: "../../flutter_midi_command_linux"
-      relative: true
-    source: path
-    version: "0.2.0"
+      name: flutter_midi_command_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   flutter_midi_command_platform_interface:
     dependency: transitive
     description:
       name: flutter_midi_command_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "0.4.0"
   flutter_midi_command_web:
     dependency: transitive
     description:
@@ -142,13 +142,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.7.0"
-  midi:
-    dependency: transitive
-    description:
-      name: midi
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.2"
   path:
     dependency: transitive
     description:

--- a/lib/flutter_midi_command_web.dart
+++ b/lib/flutter_midi_command_web.dart
@@ -141,7 +141,12 @@ class FlutterMidiCommandWeb extends MidiCommandPlatform {
     });
     print("send to devices: $data");
     for (var outport in outputPorts) {
-      outport.send(data, 1);
+      try {
+        outport.send(data, 1);
+      } catch (e, _) {
+        // currently bug in Dart-JS interop: https://github.com/flutter/flutter/issues/94945#issuecomment-1033596770
+        print('Flutter Bug: #94945 caught: $e');
+      }
     }
   }
 

--- a/lib/flutter_midi_command_web.dart
+++ b/lib/flutter_midi_command_web.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:js_util' as js_util;
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
@@ -41,8 +40,14 @@ class FlutterMidiCommandWeb extends MidiCommandPlatform {
         .requestMIDIAccess(html.MIDIOptions(sysex: true, software: false));
 
     // deal with bug: https://github.com/dart-lang/sdk/issues/33248
-    js_util.callMethod(access.inputs, 'forEach', [allowInterop(_getInputs)]);
-    js_util.callMethod(access.outputs, 'forEach', [allowInterop(_getOutputs)]);
+    // js_util.callMethod(access.inputs, 'forEach', [allowInterop(_getInputs)]);
+    // js_util.callMethod(access.outputs, 'forEach', [allowInterop(_getOutputs)]);
+    access.inputs.forEach((a, b, c) {
+      _getInputs(a, b, c);
+    });
+    access.outputs.forEach((a, b, c) {
+      _getOutputs(a, b, c);
+    });
   }
 
   void _getInputs(dynamic a, dynamic b, dynamic c) {

--- a/lib/flutter_midi_command_web.dart
+++ b/lib/flutter_midi_command_web.dart
@@ -122,18 +122,22 @@ class FlutterMidiCommandWeb extends MidiCommandPlatform {
 
   @override
   void teardown() {
-    //TODO: go through and call disconnect on all devics, then close rx stream
+    //TODO: go through and call disconnect on all devices, then close rx stream
   }
 
-  /// Sends data to the currently connected device.wmidi hardware driver name
+  /// Sends data to the currently connected devices
   ///
   /// Data is an UInt8List of individual MIDI command bytes.
   @override
   void sendData(Uint8List data, {int? timestamp, String? deviceId}) {
-    // _connectedDevices.values.forEach((device) {
-    //   // print("send to $device");
-    //   device.send(data, data.length);
-    // });
+    final outputPorts = <html.MIDIOutput>[];
+    _connectedDevices.forEach((device) {
+      outputPorts.addAll(_webMidiOutputs.where((p) => p.name == device.name));
+    });
+    print("send to devices: $data");
+    for (var outport in outputPorts) {
+      outport.send(data, 1);
+    }
   }
 
   /// Stream firing events whenever a midi package is received.

--- a/lib/flutter_midi_command_web.dart
+++ b/lib/flutter_midi_command_web.dart
@@ -94,7 +94,8 @@ class FlutterMidiCommandWeb extends MidiCommandPlatform {
 
   /// Connects to the device.
   @override
-  void connectToDevice(MidiDevice device, {List<MidiPort>? ports}) {
+  Future<void> connectToDevice(MidiDevice device,
+      {List<MidiPort>? ports}) async {
     // connect up incoming webmidi data to our rx stream of MidiPackets
     final inputPorts = _webMidiInputs.where((p) => p.name == device.name);
     for (var inport in inputPorts) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       name: flutter_midi_command_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "0.4.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       name: js_bindings
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.5"
+    version: "0.0.6-dev"
   lints:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter  
   flutter_midi_command_platform_interface: ^0.3.2
   js: ^0.6.4
-  js_bindings: 0.0.5
+  js_bindings: 0.0.6-dev
 
 dev_dependencies:
   flutter_lints: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter  
-  flutter_midi_command_platform_interface: ^0.3.2
+  flutter_midi_command_platform_interface: ^0.4.0
   js: ^0.6.4
   js_bindings: 0.0.6-dev
 

--- a/test/flutter_midi_command_web_test.dart
+++ b/test/flutter_midi_command_web_test.dart
@@ -1,19 +1,3 @@
-import 'package:flutter/services.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_midi_command_web/flutter_midi_command_web.dart';
-
 void main() {
-  const MethodChannel channel = MethodChannel('flutter_midi_command_web');
-
-  TestWidgetsFlutterBinding.ensureInitialized();
-
-  setUp(() {
-    channel.setMockMethodCallHandler((MethodCall methodCall) async {
-      return '42';
-    });
-  });
-
-  tearDown(() {
-    channel.setMockMethodCallHandler(null);
-  });
+  //TODO
 }


### PR DESCRIPTION
This PR implements sending midi data to connected devices.

It also updates to the latest version of the `js_bindings` package to longer need to use the `js_utils` workaround for accessing input, output maps.

Please note there appears to currently be a bug in Flutter master channel that causes an exception to be thrown everytiem `send()` is called, even though the midi data is actually successfully sent to the midi device.

Finally some basic docs were added to explain the intention of the example app.
